### PR TITLE
chore: replace outdated gist links with raw github content URLs

### DIFF
--- a/.claude/CLAUDE-CONTEXT-SYSTEM.md
+++ b/.claude/CLAUDE-CONTEXT-SYSTEM.md
@@ -27,7 +27,7 @@
 
 This document is maintained in the above repository as the **canonical reference**. You should periodically check for updates and implement them as appropriate for your project.
 
-**Single-file distribution**: Available at https://gist.github.com/joshrotenberg/a9f8ac85b9ebe20c6b6202a17d804fbc
+**Single-file distribution**: Available at https://raw.githubusercontent.com/joshrotenberg/claude-context-system/main/CLAUDE-CONTEXT-SYSTEM.md
 
 ### Automated Update Checking
 
@@ -1370,7 +1370,7 @@ May I proceed with: git add .claude/branches/feat/new-feature.md && git commit -
 
 When asked to check for updates:
 1. Check user's authorization for git operations first
-2. Fetch the canonical gist: https://gist.github.com/joshrotenberg/a9f8ac85b9ebe20c6b6202a17d804fbc
+2. Fetch the canonical repository: https://raw.githubusercontent.com/joshrotenberg/claude-context-system/main/CLAUDE-CONTEXT-SYSTEM.md
 3. Compare with local `.claude/CLAUDE-CONTEXT-SYSTEM.md`
 4. Identify new features, improvements, or fixes
 5. Present summary of changes with benefits/impact

--- a/.claude/branches/docs/github-as-canonical-location.md
+++ b/.claude/branches/docs/github-as-canonical-location.md
@@ -32,7 +32,7 @@ We will establish **GitHub repository as the canonical location** while maintain
 - Issue tracking and contribution workflow
 - Complete git history and branch structure
 
-**Secondary distribution:** https://gist.github.com/joshrotenberg/a9f8ac85b9ebe20c6b6202a17d804fbc  
+**Secondary distribution:** https://raw.githubusercontent.com/joshrotenberg/claude-context-system/main/CLAUDE-CONTEXT-SYSTEM.md  
 - Single-file `CLAUDE-CONTEXT-SYSTEM.md` for easy copying
 - Updated automatically from canonical repository
 - Perfect for users who just want to copy the system

--- a/CLAUDE-CONTEXT-SYSTEM.md
+++ b/CLAUDE-CONTEXT-SYSTEM.md
@@ -27,7 +27,7 @@
 
 This document is maintained in the above repository as the **canonical reference**. You should periodically check for updates and implement them as appropriate for your project.
 
-**Single-file distribution**: Available at https://gist.github.com/joshrotenberg/a9f8ac85b9ebe20c6b6202a17d804fbc
+**Single-file distribution**: Available at https://raw.githubusercontent.com/joshrotenberg/claude-context-system/main/CLAUDE-CONTEXT-SYSTEM.md
 
 ### Automated Update Checking
 
@@ -1370,7 +1370,7 @@ May I proceed with: git add .claude/branches/feat/new-feature.md && git commit -
 
 When asked to check for updates:
 1. Check user's authorization for git operations first
-2. Fetch the canonical gist: https://gist.github.com/joshrotenberg/a9f8ac85b9ebe20c6b6202a17d804fbc
+2. Fetch the canonical repository: https://raw.githubusercontent.com/joshrotenberg/claude-context-system/main/CLAUDE-CONTEXT-SYSTEM.md
 3. Compare with local `.claude/CLAUDE-CONTEXT-SYSTEM.md`
 4. Identify new features, improvements, or fixes
 5. Present summary of changes with benefits/impact

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ That's it! No installation, no dependencies, just natural conversation with your
 
 ## 📍 Get the System
 
-**Single-file distribution:** [Download CLAUDE-CONTEXT-SYSTEM.md](https://gist.github.com/joshrotenberg/a9f8ac85b9ebe20c6b6202a17d804fbc)
+**Single-file distribution:** [Download CLAUDE-CONTEXT-SYSTEM.md](https://raw.githubusercontent.com/joshrotenberg/claude-context-system/main/CLAUDE-CONTEXT-SYSTEM.md)
 
 **Canonical location:** This repository contains the complete system with live dogfooding demonstration.
 
@@ -118,7 +118,7 @@ just demo      # System demonstration
 
 ## 🔗 Links
 
-- **Download system:** [Single-file gist](https://gist.github.com/joshrotenberg/a9f8ac85b9ebe20c6b6202a17d804fbc)
+- **Download system:** [Raw file download](https://raw.githubusercontent.com/joshrotenberg/claude-context-system/main/CLAUDE-CONTEXT-SYSTEM.md)
 - **Full repository:** [GitHub](https://github.com/joshrotenberg/claude-context-system)
 - **Live demo:** Explore `.claude/` in this repository
 


### PR DESCRIPTION
## Summary

Replaces all references to the outdated GitHub Gist with direct raw GitHub content URLs to ensure users always get the latest version of the system.

## Changes

- **README.md**: Update download links from Gist to raw GitHub file
- **CLAUDE-CONTEXT-SYSTEM.md**: Update canonical references and update protocol
- **.claude/ copy**: Keep local copy consistent with main file
- **ADR documentation**: Update references in existing architectural decisions

## Impact

- Users will always download the current version instead of potentially outdated Gist
- Prepares for making the Gist private as requested
- Maintains single source of truth in the canonical repository
- No functional changes to the system itself

## Testing

- [x] Verified all gist.github.com references removed
- [x] Confirmed raw GitHub URLs are accessible
- [x] Validated file content consistency across copies

Closes the outdated distribution link issue mentioned in previous discussions.